### PR TITLE
Disable rpaths during linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+cache: apt
+language:
+  - cpp
+python:
+  - "2.7"
+compiler:
+  - gcc
+before_install:
+  - export CI_SOURCE_PATH=$(pwd)
+  - export REPOSITORY_NAME=${PWD##*/}
+  - export ROS_DISTRO=hydro
+  - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
+  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - sudo apt-get update
+  - sudo apt-get -qq install git python-catkin-tools python-rosdep ros-${ROS_DISTRO}-rosbash ros-${ROS_DISTRO}-rospack
+  - mkdir -p ~/catkin_ws/src
+  - cd ~/catkin_ws/src
+  - git clone --depth 1 https://github.com/tork-a/euslisp-release euslisp
+  - cp -r ${CI_SOURCE_PATH}/patches/* euslisp/
+  - sed -i 's@:{version}@0.0.0@' euslisp/package.xml
+  - git clone --depth 1 https://github.com/tork-a/jskeus-release jskeus
+  - cd ..
+  - sudo rosdep init; rosdep update; rosdep install --from-paths src --ignore-src
+  - source /opt/ros/hydro/setup.bash
+install:
+  - catkin build -v -i
+script:
+  - ls -al devel
+  - source devel/setup.bash
+  - env
+  - cd devel/share/euslisp
+  - find jskeus/irteus/test -iname "*.l" | grep -v unittest.l | xargs -n1 irteusgl
+notifications:
+  email:
+    on_success: always
+    on_failure: always

--- a/patches/CMakeLists.txt
+++ b/patches/CMakeLists.txt
@@ -32,10 +32,10 @@ add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/lisp/Makefile
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/lisp/)
 add_custom_target(compile_euslisp ALL
   DEPENDS ${PROJECT_SOURCE_DIR}/lisp/Makefile
-  COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile EUSRPATH=)
+  COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} LD_LIBRARY_PATH=${PROJECT_SOURCE_DIR}/${ARCHDIR}/lib:\$LD_LIBRARY_PATH && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile EUSRPATH=)
 
 add_custom_target(install_euslisp
-  COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && ${CMAKE_COMMAND} -E make_directory \${DESTDIR}${CMAKE_INSTALL_PREFIX}/bin && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile install PUBBINDIR=\${DESTDIR}${CMAKE_INSTALL_PREFIX}/bin)
+  COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} LD_LIBRARY_PATH=${PROJECT_SOURCE_DIR}/${ARCHDIR}/lib:\$LD_LIBRARY_PATH && ${CMAKE_COMMAND} -E make_directory \${DESTDIR}${CMAKE_INSTALL_PREFIX}/bin && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile install PUBBINDIR=\${DESTDIR}${CMAKE_INSTALL_PREFIX}/bin)
 
 install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target install_euslisp)")
 install(DIRECTORY contrib doc lib lisp models ${ARCHDIR}

--- a/patches/CMakeLists.txt
+++ b/patches/CMakeLists.txt
@@ -32,7 +32,7 @@ add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/lisp/Makefile
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/lisp/)
 add_custom_target(compile_euslisp ALL
   DEPENDS ${PROJECT_SOURCE_DIR}/lisp/Makefile
-  COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile)
+  COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile EUSRPATH=)
 
 add_custom_target(install_euslisp
   COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && ${CMAKE_COMMAND} -E make_directory \${DESTDIR}${CMAKE_INSTALL_PREFIX}/bin && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile install PUBBINDIR=\${DESTDIR}${CMAKE_INSTALL_PREFIX}/bin)


### PR DESCRIPTION
This is a follow-up patch to https://github.com/euslisp/EusLisp/pull/95

The rpath generated is to a temporary build directory that is not present on target systems. The paths resolve just fine once the appropriate `setup.sh` is sourced, anyway.

Example of an incorrect rpath from Ubuntu trusty with `ros-indigo-euslisp-9.11.0-1trusty-20150219-1548-+0000`:

```
cottsay@cottsay-ubuntu:~$ chrpath -l /opt/ros/indigo/share/euslisp/jskeus/eus/Linux64/bin/eus
/opt/ros/indigo/share/euslisp/jskeus/eus/Linux64/bin/eus: RPATH=/tmp/buildd/ros-indigo-euslisp-9.11.0-1trusty-20150219-1548/Linux64/lib
```

Thanks,

--scott

**EDIT:** I added a commit that adds to the `LD_LIBRARY_PATH` like `99.euslisp` does. I didn't initially catch this because I had an older version of `ros-indigo-euslisp` already installed on the machine I was building on...
