### PR TITLE
Remove trailing slash from EUSDIR

### DIFF
--- a/patches/cmake/euslisp-extras.cmake.in
+++ b/patches/cmake/euslisp-extras.cmake.in
@@ -1,5 +1,5 @@
 # euslisp.cmake
-set(EUSDIR @CMAKE_INSTALL_PREFIX@/share/euslisp/jskeus/eus/)
+set(EUSDIR @CMAKE_INSTALL_PREFIX@/share/euslisp/jskeus/eus)
 set(ARCHDIR @ARCHDIR@)
 set(euslisp_INCLUDE_DIRS ${EUSDIR}/include)
 message("-- set EUSDIR to ${EUSDIR}")


### PR DESCRIPTION
This one is a little bit weird, even for me. The trailing slash causes the paths in downstream packages to have two slashes in them. Later in the build process, the double slash is collapsed into a single one, and that makes debuginfo extraction puke.

The trailing slash isn't needed, so removing it is probably the best move.

It took me FOREVER to root-cause this bug...

Example failure: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-jskeus_binaryrpm_heisenbug_x86_64/25/consoleFull

Thanks,

--scott
