### PR TITLE
[euslisp-release] disable parallel build euslisp in OSX environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin)
 
 # check arch and os
 execute_process(COMMAND bash -c "gcc -dumpmachine" OUTPUT_VARIABLE gcc_dump_machine OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(MAKEOPTION "")
 message("-- gcc dumpmachine returns ${gcc_dump_machine}")
 if(gcc_dump_machine MATCHES "x86_64-*")
   set(ARCHDIR "Linux64")
@@ -22,6 +23,7 @@ elseif(gcc_dump_machine MATCHES "cygwin*-*")
 elseif(gcc_dump_machine MATCHES "darwin*-*")
   set(ARCHDIR "Darwin")
   set(MAKEFILE "Makefile.Darwin")
+  set(MAKEOPTION "-j1") # disable parallel build
 else()
   message(FATAL_ERROR "-- -- This machine is not supported")
 endif()
@@ -32,10 +34,10 @@ add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/lisp/Makefile
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/lisp/)
 add_custom_target(compile_euslisp ALL
   DEPENDS ${PROJECT_SOURCE_DIR}/lisp/Makefile
-  COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile)
+  COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && \$\(MAKE\) ${MAKEOPTION} -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile)
 
 add_custom_target(install_euslisp
-  COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && ${CMAKE_COMMAND} -E make_directory \${DESTDIR}${CMAKE_INSTALL_PREFIX}/bin && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile install PUBBINDIR=\${DESTDIR}${CMAKE_INSTALL_PREFIX}/bin)
+  COMMAND export EUSDIR=${PROJECT_SOURCE_DIR} lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && ${CMAKE_COMMAND} -E make_directory \${DESTDIR}${CMAKE_INSTALL_PREFIX}/bin && \$\(MAKE\) ${MAKEOPTION} -C ${PROJECT_SOURCE_DIR}/lisp -f Makefile install PUBBINDIR=\${DESTDIR}${CMAKE_INSTALL_PREFIX}/bin)
 
 install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target install_euslisp)")
 install(DIRECTORY contrib doc lib lisp models ${ARCHDIR}


### PR DESCRIPTION
it fails to make euslisp parallel in OS X/clang environment.
