### PR TITLE
use libpng-dev instead of libpng12-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ compiler:
 before_install:
   - export CI_SOURCE_PATH=$(pwd)
   - export REPOSITORY_NAME=${PWD##*/}
-  - export ROS_DISTRO=hydro
+  - export ROS_DISTRO=indigo
   - echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME"
   - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
@@ -22,7 +22,7 @@ before_install:
   - git clone --depth 1 https://github.com/tork-a/jskeus-release jskeus
   - cd ..
   - sudo rosdep init; rosdep update; rosdep install --from-paths src --ignore-src
-  - source /opt/ros/hydro/setup.bash
+  - source /opt/ros/${ROS_DISTRO}/setup.bash
 install:
   - catkin build -v -i
 script:

--- a/patches/package.xml
+++ b/patches/package.xml
@@ -19,7 +19,7 @@
   <build_depend>libjpeg</build_depend>
   <build_depend>libx11-dev</build_depend>
   <build_depend>libxext</build_depend>
-  <build_depend>libpng12-dev</build_depend>
+  <build_depend>libpng-dev</build_depend>
   <build_depend>libpq-dev</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>mk</build_depend>
@@ -30,7 +30,7 @@
   <run_depend>libjpeg</run_depend>
   <run_depend>libx11-dev</run_depend>
   <run_depend>libxext</run_depend>
-  <run_depend>libpng12-dev</run_depend>
+  <run_depend>libpng-dev</run_depend>
   <run_depend>libpq-dev</run_depend>
   <run_depend>xfonts-100dpi</run_depend>
   <run_depend>xfonts-75dpi</run_depend>


### PR DESCRIPTION
from trusty libpng-dev is available instead of libpng12-dev and from bionic, libpng12-dev is no longer provided https://packages.ubuntu.com/search?keywords=libpng